### PR TITLE
Added charge animation offset.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -230,6 +230,8 @@
     <string name="batterybar_height_dialog">Height of BatteryBar in dp.\n(Non-numeric characters are ignored.)</string>
     <string name="batterybar_animate_title">Animate Charging</string>
     <string name="batterybar_animate_summary">Show Animation while Charging</string>
+    <string name="batterybar_animate_offset">Animation Offset</string>
+    <string name="batterybar_animate_offset_summary">Time between animations</string>
     <string name="batterybar_color_title">BatteryBar Color</string>
     
     <string name="batterybar_color_screen_title">Customize Color</string>

--- a/res/xml/pref_setting.xml
+++ b/res/xml/pref_setting.xml
@@ -95,7 +95,7 @@
             android:dependency="batterybar_animate"
             android:summary="@string/batterybar_animate_offset_summary"
             android:title="@string/batterybar_animate_offset" />
-        
+
         <CheckBoxPreference
             android:dependency="batterybar_enable"
             android:key="batterybar_style"

--- a/res/xml/pref_setting.xml
+++ b/res/xml/pref_setting.xml
@@ -84,6 +84,18 @@
             android:summary="@string/batterybar_animate_summary"
             android:title="@string/batterybar_animate_title" />
         
+        <com.zst.xposed.xuimod.preference.SeekBarDialog
+            defaultValue="0"
+            maximum="12000"
+            minimum="0"
+            suffix="ms"
+            android:dialogLayout="@layout/pref_seekbar"
+            android:dialogTitle="@string/batterybar_animate_offset"
+            android:key="batterybar_animate_offset"
+            android:dependency="batterybar_animate"
+            android:summary="@string/batterybar_animate_offset_summary"
+            android:title="@string/batterybar_animate_offset" />
+        
         <CheckBoxPreference
             android:dependency="batterybar_enable"
             android:key="batterybar_style"

--- a/src/com/zst/xposed/xuimod/Common.java
+++ b/src/com/zst/xposed/xuimod/Common.java
@@ -59,6 +59,7 @@ public class Common {
 	
 	public static final String KEY_BATTERYBAR_ENABLE = "batterybar_enable";
 	public static final String KEY_BATTERYBAR_ANIMATE = "batterybar_animate";
+	public static final String KEY_BATTERYBAR_ANIMATE_OFFSET = "batterybar_animate_offset";
 	public static final String KEY_BATTERYBAR_STYLE = "batterybar_style";
 	public static final String[] KEYS_BATTERYBAR_POSITION = new String[] {
 		"batterybar_position_sb",
@@ -167,6 +168,7 @@ public class Common {
 	
 	public static final boolean DEFAULT_BATTERYBAR_ENABLE = false;
 	public static final boolean DEFAULT_BATTERYBAR_ANIMATE = false;
+	public static final int DEFAULT_BATTERYBAR_ANIMATE_OFFSET = 0;
 	public static final boolean DEFAULT_BATTERYBAR_STYLE = false;
 	public static final String DEFAULT_BATTERYBAR_COLOR_MODE = "0";
 	public static final String DEFAULT_BATTERYBAR_COLOR = COLOR_HOLO_BLUE;

--- a/src/com/zst/xposed/xuimod/mods/batterybar/BatteryBarView.java
+++ b/src/com/zst/xposed/xuimod/mods/batterybar/BatteryBarView.java
@@ -195,8 +195,14 @@ public class BatteryBarView extends RelativeLayout implements Animatable {
     	mSymmetric = pref.getBoolean(Common.KEY_BATTERYBAR_STYLE,
     			Common.DEFAULT_BATTERYBAR_STYLE);
 
-        ANIM_OFFSET = pref.getInt(Common.KEY_BATTERYBAR_ANIMATE_OFFSET,
+        int tempAnimOffset = pref.getInt(Common.KEY_BATTERYBAR_ANIMATE_OFFSET,
         		Common.DEFAULT_BATTERYBAR_ANIMATE_OFFSET);
+        
+        if(tempAnimOffset != ANIM_OFFSET) {
+        	ANIM_OFFSET = tempAnimOffset;
+        	stop();
+        	start();
+        }
 
         setProgress(mBatteryLevel);
         updateBatteryColor();

--- a/src/com/zst/xposed/xuimod/mods/batterybar/BatteryBarView.java
+++ b/src/com/zst/xposed/xuimod/mods/batterybar/BatteryBarView.java
@@ -44,6 +44,7 @@ import android.widget.RelativeLayout;
 public class BatteryBarView extends RelativeLayout implements Animatable {
     // Total animation duration
     private static final int ANIM_DURATION = 1000; // 1 second
+    private static int ANIM_OFFSET = 0; // Time between animations in milliseconds.
     
     public static final int MODE_COLOR_SINGLE = 0;
     public static final int MODE_COLOR_MULTIPLE = 1;
@@ -302,6 +303,9 @@ public class BatteryBarView extends RelativeLayout implements Animatable {
         Display display = ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE))
     			.getDefaultDisplay();
         
+        ANIM_OFFSET = mPref.getInt(Common.KEY_BATTERYBAR_ANIMATE_OFFSET,
+        		Common.DEFAULT_BATTERYBAR_ANIMATE_OFFSET);
+        
         if (vertical) {
         	int height = display.getHeight();
         	if (mSymmetric) {
@@ -312,6 +316,7 @@ public class BatteryBarView extends RelativeLayout implements Animatable {
             a.setInterpolator(new AccelerateInterpolator());
             a.setDuration(ANIM_DURATION);
             a.setRepeatCount(Animation.INFINITE);
+            a.setStartOffset(ANIM_OFFSET);
             mChargerLayout.startAnimation(a);
             mChargerLayout.setVisibility(View.VISIBLE);
         } else {
@@ -324,6 +329,7 @@ public class BatteryBarView extends RelativeLayout implements Animatable {
             a.setInterpolator(new AccelerateInterpolator());
             a.setDuration(ANIM_DURATION);
             a.setRepeatCount(Animation.INFINITE);
+            a.setStartOffset(ANIM_OFFSET);
             mChargerLayout.startAnimation(a);
             mChargerLayout.setVisibility(View.VISIBLE);
         }

--- a/src/com/zst/xposed/xuimod/mods/batterybar/BatteryBarView.java
+++ b/src/com/zst/xposed/xuimod/mods/batterybar/BatteryBarView.java
@@ -194,7 +194,10 @@ public class BatteryBarView extends RelativeLayout implements Animatable {
     	
     	mSymmetric = pref.getBoolean(Common.KEY_BATTERYBAR_STYLE,
     			Common.DEFAULT_BATTERYBAR_STYLE);
-    	
+
+        ANIM_OFFSET = pref.getInt(Common.KEY_BATTERYBAR_ANIMATE_OFFSET,
+        		Common.DEFAULT_BATTERYBAR_ANIMATE_OFFSET);
+
         setProgress(mBatteryLevel);
         updateBatteryColor();
         updateBatteryBackground();
@@ -302,9 +305,6 @@ public class BatteryBarView extends RelativeLayout implements Animatable {
 
         Display display = ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE))
     			.getDefaultDisplay();
-        
-        ANIM_OFFSET = mPref.getInt(Common.KEY_BATTERYBAR_ANIMATE_OFFSET,
-        		Common.DEFAULT_BATTERYBAR_ANIMATE_OFFSET);
         
         if (vertical) {
         	int height = display.getHeight();


### PR DESCRIPTION
I loved the battery bar charging animation, but I got stressed out and distracted from how quickly it fired so I added the option to set an offset between animations.
You might need to restart the system UI to see the difference. (Slowly de- and reactivating the charge animation works as well. It just needs start() to run. I'll try to make it cleaner once I fully figure out your code.)
